### PR TITLE
Dependencies: Fix Proxies not counting for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ sbox-pool.csproj
 .intermediate
 *bakeresourcecache*
 tools_*_*.bin
+code/sbox-rts.csproj

--- a/code/entities/Player.cs
+++ b/code/entities/Player.cs
@@ -64,6 +64,44 @@ namespace Facepunch.RTS
 			return All.OfType<UnitEntity>().Where( i => i.Player == this );
 		}
 
+		private bool IsProxyOfBuilding ( BaseBuilding proxy, BaseBuilding building, Dictionary<string, bool> checkedProxies )
+		{
+			if ( proxy == building ) return true;
+
+			string uniqueId = proxy.UniqueId;
+			bool isChecked;
+
+			checkedProxies.TryGetValue( uniqueId, out isChecked );
+
+			if ( isChecked ) return false;
+
+			checkedProxies.Add( uniqueId, true );
+
+			var proxyList = proxy.ActsAsProxyFor;
+
+			for ( var i = 0; i < proxyList.Length; i++ )
+			{
+				var proxyItem = Items.Find<BaseBuilding>( proxyList[i] );
+
+				if ( proxyItem != null && IsProxyOfBuilding( proxyItem, building, checkedProxies ) ) 
+					return true;
+			}
+
+			return false;
+		}
+
+		private bool IsProxyOfBuilding ( BaseBuilding proxy, BaseBuilding building )
+		{
+			Dictionary<string, bool> checkedProxies = new Dictionary<string, bool>( 5 );
+
+			return IsProxyOfBuilding( proxy, building, checkedProxies );
+		}
+
+		public IEnumerable<BuildingEntity> GetBuildingsProxiesIncluded( BaseBuilding building )
+		{
+			return All.OfType<BuildingEntity>().Where( i => i.Player == this && IsProxyOfBuilding( i.Item, building ) );
+		}
+
 		public IEnumerable<BuildingEntity> GetBuildings( BaseBuilding building )
 		{
 			return All.OfType<BuildingEntity>().Where( i => i.Player == this && i.Item == building );
@@ -273,14 +311,19 @@ namespace Facepunch.RTS
 
 		public void RemoveDependency( BaseItem item )
 		{
-			if ( Dependencies.Contains( item.NetworkId ) )
+			if ( HasDependency( item ) )
 				Dependencies.Remove( item.NetworkId );
 		}
 
 		public void AddDependency( BaseItem item )
 		{
-			if ( !Dependencies.Contains( item.NetworkId ) )
+			if ( !HasDependency( item ) )
 				Dependencies.Add( item.NetworkId );
+		}
+
+		public bool HasDependency( BaseItem item )
+		{
+			return Dependencies.Contains( item.NetworkId );
 		}
 
 		public void ClearSelection()

--- a/code/entities/items/BuildingEntity.cs
+++ b/code/entities/items/BuildingEntity.cs
@@ -780,7 +780,7 @@ namespace Facepunch.RTS
 			{
 				var proxyItem = Items.Find<BaseBuilding>( proxyList[i] );
 				if ( proxyItem == null || Player.HasDependency( proxyItem ) ) continue;
-				
+
 				AddDependencies( proxyItem );
 			}
 		}

--- a/code/entities/items/BuildingEntity.cs
+++ b/code/entities/items/BuildingEntity.cs
@@ -779,17 +779,17 @@ namespace Facepunch.RTS
 			for ( var i = 0; i < proxyList.Length; i++ )
 			{
 				var proxyItem = Items.Find<BaseBuilding>( proxyList[i] );
-				if ( proxyItem == null ) continue;
-
-				Player.AddDependency( proxyItem );
+				if ( proxyItem == null || Player.HasDependency( proxyItem ) ) continue;
+				
+				AddDependencies( proxyItem );
 			}
 		}
 
 		private void RemoveDependencies( BaseBuilding item )
 		{
-			var others = Player.GetBuildings( item );
+			var others = Player.GetBuildingsProxiesIncluded( item );
 
-			if ( others.Count() == 1 )
+			if ( others.Count() <= 1 )
 				Player.RemoveDependency( item );
 
 			var proxyList = item.ActsAsProxyFor;
@@ -797,12 +797,9 @@ namespace Facepunch.RTS
 			for ( var i = 0; i < proxyList.Length; i++ )
 			{
 				var proxyItem = Items.Find<BaseBuilding>( proxyList[i] );
-				if ( proxyItem == null ) continue;
+				if ( proxyItem == null || !Player.HasDependency( proxyItem ) ) continue;
 
-				others = Player.GetBuildings( proxyItem );
-
-				if ( others.Count() == 1 )
-					Player.RemoveDependency( proxyItem );
+				RemoveDependencies( proxyItem );
 			}
 		}
 

--- a/code/items/buildings/MegaCommandCentre.cs
+++ b/code/items/buildings/MegaCommandCentre.cs
@@ -12,6 +12,7 @@ namespace Facepunch.RTS.Buildings
 		{
 			"ability_airstrike"
 		};
+		public override string[] ActsAsProxyFor => new string[] { "building.commandcentre2" };
 		public override string Model => "models/buildings/headquarters/headquarters_level3.vmdl";
 	}
 }

--- a/code/sbox-rts.csproj
+++ b/code/sbox-rts.csproj
@@ -23,14 +23,14 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<Analyzer Include="C:/Spiele/Steam/steamapps/common/sbox/bin/managed/Sandbox.Generator.dll"/>
-		<Reference Include="C:/Spiele/Steam/steamapps/common/sbox/bin/managed/Sandbox.System.dll"/>
-		<Reference Include="C:/Spiele/Steam/steamapps/common/sbox/bin/managed/Sandbox.Engine.dll"/>
-		<Reference Include="C:/Spiele/Steam/steamapps/common/sbox/bin/managed/Sandbox.Game.dll"/>
+		<Analyzer Include="H:/Facepunch/sbox/game/bin/managed/Sandbox.Generator.dll"/>
+		<Reference Include="H:/Facepunch/sbox/game/bin/managed/Sandbox.System.dll"/>
+		<Reference Include="H:/Facepunch/sbox/game/bin/managed/Sandbox.Engine.dll"/>
+		<Reference Include="H:/Facepunch/sbox/game/bin/managed/Sandbox.Game.dll"/>
 	</ItemGroup>
 
   <ItemGroup>
-<ProjectReference Include="C:\Spiele\Steam\steamapps\common\sbox\Addons\base\code\base.csproj" />
+<ProjectReference Include="H:\Facepunch\sbox\game\Addons\base\code\base.csproj" />
   </ItemGroup>
 
 </Project>

--- a/code/sbox-rts.csproj
+++ b/code/sbox-rts.csproj
@@ -23,14 +23,14 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<Analyzer Include="H:/Facepunch/sbox/game/bin/managed/Sandbox.Generator.dll"/>
-		<Reference Include="H:/Facepunch/sbox/game/bin/managed/Sandbox.System.dll"/>
-		<Reference Include="H:/Facepunch/sbox/game/bin/managed/Sandbox.Engine.dll"/>
-		<Reference Include="H:/Facepunch/sbox/game/bin/managed/Sandbox.Game.dll"/>
+		<Analyzer Include="C:/Spiele/Steam/steamapps/common/sbox/bin/managed/Sandbox.Generator.dll"/>
+		<Reference Include="C:/Spiele/Steam/steamapps/common/sbox/bin/managed/Sandbox.System.dll"/>
+		<Reference Include="C:/Spiele/Steam/steamapps/common/sbox/bin/managed/Sandbox.Engine.dll"/>
+		<Reference Include="C:/Spiele/Steam/steamapps/common/sbox/bin/managed/Sandbox.Game.dll"/>
 	</ItemGroup>
 
   <ItemGroup>
-<ProjectReference Include="H:\Facepunch\sbox\game\Addons\base\code\base.csproj" />
+<ProjectReference Include="C:\Spiele\Steam\steamapps\common\sbox\Addons\base\code\base.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Only wanting to fix the mega command centredisabling buildings of former upgrades,  #109 
I got into the mess of proxies being dependent on each other and integrated a deep search, such that you only need to add the buildings you really upgrade from. Otherwise we could later run into a 6th command centre upgrade, that has to add all former 5 CCs.

On a sidenote, can we add a file to .gitignore. Not sure how we keep sbox-rts.csproj separate otherwise.