### PR TITLE
Build Preview: Fix Physics Collider Update

### DIFF
--- a/code/entities/client/GhostBuilding.cs
+++ b/code/entities/client/GhostBuilding.cs
@@ -13,6 +13,15 @@ namespace Facepunch.RTS
 		public BaseBuilding Building { get; private set; }
 		public UnitEntity Worker { get; private set; }
 		public bool IsTouchingBlocker { get; private set; }
+		public override Vector3 Position
+		{
+			get => base.Position;
+			set
+			{
+				base.Position = value;
+				PhysicsBody.Position = value;
+			}
+		}
 
 		public GhostBuilding()
 		{


### PR DESCRIPTION
Instead of waiting for the engine to handle the physics update, we force the physicsbody to be at the same spot as the current position. As we dont need real physics on ghost-buildings, this should be okay.
Solves #107 partly and maybe #98 fully.