### PR TITLE
Bugfix: Moved IsProxyOf to Basebuildings and fixed the Moved Code

### DIFF
--- a/code/entities/Player.cs
+++ b/code/entities/Player.cs
@@ -67,7 +67,7 @@ namespace Facepunch.RTS
 
 		public IEnumerable<BuildingEntity> GetBuildingsProxiesIncluded( BaseBuilding building )
 		{
-			return All.OfType<BuildingEntity>().Where( i => i.Player == this && i.IsProxyOf( building ) );
+			return All.OfType<BuildingEntity>().Where( i => i.Player == this && i.Item.IsProxyOf( building ) );
 		}
 
 		public IEnumerable<BuildingEntity> GetBuildings( BaseBuilding building )

--- a/code/entities/items/BuildingEntity.cs
+++ b/code/entities/items/BuildingEntity.cs
@@ -149,39 +149,6 @@ namespace Facepunch.RTS
 			}
 		}
 
-		public bool IsProxyOf( BaseBuilding other, Dictionary<string, bool> checkedProxies )
-		{
-			if ( other == Item ) return true;
-
-			string uniqueId = other.UniqueId;
-			bool isChecked;
-
-			checkedProxies.TryGetValue( uniqueId, out isChecked );
-
-			if ( isChecked ) return false;
-
-			checkedProxies.Add( uniqueId, true );
-
-			var proxyList = other.ActsAsProxyFor;
-
-			for ( var i = 0; i < proxyList.Length; i++ )
-			{
-				var proxyItem = Items.Find<BaseBuilding>( proxyList[i] );
-
-				if ( proxyItem != null && IsProxyOf( proxyItem, checkedProxies ) )
-					return true;
-			}
-
-			return false;
-		}
-
-		public bool IsProxyOf( BaseBuilding other )
-		{
-			var checkedProxies = new Dictionary<string, bool>( 5 );
-
-			return IsProxyOf( other, checkedProxies );
-		}
-
 		public void UpdateRepair()
 		{
 			Host.AssertServer();

--- a/code/items/buildings/BaseBuilding.cs
+++ b/code/items/buildings/BaseBuilding.cs
@@ -74,5 +74,35 @@ namespace Facepunch.RTS.Buildings
 		{
 			return true;
 		}
+
+		public bool IsProxyOf( BaseBuilding other, Dictionary<string, bool> checkedProxies )
+		{
+			if ( other == this ) return true;
+
+			bool isChecked;
+
+			checkedProxies.TryGetValue( UniqueId, out isChecked );
+
+			if ( isChecked ) return false;
+
+			checkedProxies.Add( UniqueId, true );
+
+			for ( var i = 0; i < ActsAsProxyFor.Length; i++ )
+			{
+				var proxyItem = Items.Find<BaseBuilding>( ActsAsProxyFor[i] );
+
+				if ( proxyItem != null && proxyItem.IsProxyOf( other, checkedProxies ) )
+					return true;
+			}
+
+			return false;
+		}
+
+		public bool IsProxyOf( BaseBuilding other )
+		{
+			var checkedProxies = new Dictionary<string, bool>( 5 );
+
+			return IsProxyOf( other, checkedProxies );
+		}
 	}
 }

--- a/code/items/buildings/CommandCentre.cs
+++ b/code/items/buildings/CommandCentre.cs
@@ -15,7 +15,7 @@ namespace Facepunch.RTS.Buildings
 		public override float MinLineOfSight => 500f;
 		public override bool BuildFirstInstantly => true;
 		public override int BuildTime => 60;
-		public override bool CanDemolish => false;
+		public override bool CanDemolish => true;
 		public override Dictionary<ResourceType, int> Costs => new()
 		{
 			[ResourceType.Stone] = 1000,


### PR DESCRIPTION
The ported code compared the wrong entities. Now the code is directly implemented in basebuildings and fixes the old bug again, that building a mega-command-centre removes dependencies of the first command-centre.

And maybe allow CCs to be demolished? Sometimes you need the place (also its easier to test :stuck_out_tongue_closed_eyes:)