### PR TITLE
item tooltip and dependency value ui fixes

### DIFF
--- a/code/ui/DependencyValue.cs
+++ b/code/ui/DependencyValue.cs
@@ -15,26 +15,26 @@ namespace Facepunch.RTS
 		{
 			StyleSheet.Load( "/ui/DependencyValue.scss" );
 
-			//Icon = Add.Panel( "icon" );
+			Icon = Add.Panel( "icon" );
 			Label = Add.Label( "", "label" );
 		}
 
 		public void Update( BaseItem dependency )
 		{
-			//var icon = dependency.Icon;
+			var icon = dependency.Icon;
 
-			//if ( icon != null )
-			//{
-			//	Style.BackgroundImage = icon;
-			//	Style.BackgroundSizeX = Length.Percent( 100f );
-			//	Style.BackgroundSizeY = Length.Percent( 100f );
-			//}
-			//else
-			//{
-			//	Style.BackgroundImage = null;
-			//	Style.BackgroundSizeX = null;
-			//	Style.BackgroundSizeY = null;
-			//}
+			if ( icon != null )
+			{
+				Icon.Style.BackgroundImage = icon;
+				Icon.Style.BackgroundSizeX = Length.Percent( 100f );
+				Icon.Style.BackgroundSizeY = Length.Percent( 100f );
+			}
+			else
+			{
+				Icon.Style.BackgroundImage = null;
+				Icon.Style.BackgroundSizeX = null;
+				Icon.Style.BackgroundSizeY = null;
+			}
 
 			Label.Text = dependency.Name;
 		}

--- a/code/ui/DependencyValue.scss
+++ b/code/ui/DependencyValue.scss
@@ -8,8 +8,8 @@
         margin-right: 4px;
         box-shadow: 0px 0px 10px 1px rgba(255,0,0,0.1);
         border-radius: 2px;
-        width: 24px;
-        height: 24px;
+        width: 32px;
+        height: 32px;
     }
 
     .label {

--- a/code/ui/ItemTooltip.scss
+++ b/code/ui/ItemTooltip.scss
@@ -12,6 +12,7 @@
     transform: translateX(-50%) translateY(-100%);
     left: 0px;
     top: 0px;
+    z-index: 10;
 
     .name {
         font-size: 20px;


### PR DESCRIPTION
apply icon style to icon panel instead of the parent panel, fixes stretched image on dependency value panel

adjust size of dependency value icon based on feedback

increase z-index of item tooltip panel to prevent z-fighting